### PR TITLE
[3.x] allow modification of the personal team using an optional callable

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -51,8 +51,6 @@ class UserFactory extends Factory
 
     /**
      * Indicate that the user should have a personal team.
-     *
-     * @return $this
      */
     public function withPersonalTeam(callable $modify = null): static
     {

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -51,8 +51,10 @@ class UserFactory extends Factory
 
     /**
      * Indicate that the user should have a personal team.
+     *
+     * @return $this
      */
-    public function withPersonalTeam(): static
+    public function withPersonalTeam(callable $modify = null): static
     {
         if (! Features::hasTeamFeatures()) {
             return $this->state([]);
@@ -60,9 +62,12 @@ class UserFactory extends Factory
 
         return $this->has(
             Team::factory()
-                ->state(function (array $attributes, User $user) {
-                    return ['name' => $user->name.'\'s Team', 'user_id' => $user->id, 'personal_team' => true];
-                }),
+                ->state(fn (array $attributes, User $user) => [
+                    'name' => $user->name.'\'s Team',
+                    'user_id' => $user->id,
+                    'personal_team' => true,
+                ])
+                ->when($modify, $modify),
             'ownedTeams'
         );
     }


### PR DESCRIPTION
# Changes

* User Factory in the database/factories folder

# Why

Allows for modification of the withPersonalTeam method so that a callable can be passed to the method to further modify the team factory, for example:

```php
User::factory()->withPersonalTeam(
  fn (TeamFactory $factory) => $factory
    ->state([
        'foo' => 'bar',
    ])
    ->has(
        Post::factory()
            ->count(10)
    )
)
->create();
```
